### PR TITLE
Restore order of Developer Tools deals and fix ToC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Don't forget to:
 - [🤖 AI Tools](#-ai-tools)
 - [🌅 Design Tools](#-design-tools)
 - [🖥️ System Utilities](#%EF%B8%8F-system-utilities)
-- [👨‍💻 Developer Tools](#-developer-tools)
+- [👨‍💻 Developer Tools](#%E2%80%8D-developer-tools)
 - [👨‍🎨 Others](#%EF%B8%8F-others)
 
 ## 🔥 Productivity
@@ -67,8 +67,8 @@ Don't forget to:
 ## 👨‍💻 Developer Tools
 | Badge | App | Category | Description | Deal | Start-End Date |
 |:---:|:---|:---|:---|:---|:---:|
-| 🔥 | [KeygenGo](https://keygengo.5km.tech) | Licensing & Distribution | A native macOS app that transforms your Keygen.sh experience. Manage licenses, track users, and monitor products through an elegant visual interface. | 50% OFF for Lifetime Plan with code **BF2025** |  Nov 20 - Dec 2  |
 | 🔥 | [Dash](https://kapeli.com/dash)|Documentation Browser|Offline API Documentation browser and snippet manager|50% OFF with code [BLACKFRIDAY](https://kapeli.com/subscribe?coupon=BLACKFRIDAY)|Nov 4 - Nov 12|
+| 🔥 | [KeygenGo](https://keygengo.5km.tech) | Licensing & Distribution | A native macOS app that transforms your Keygen.sh experience. Manage licenses, track users, and monitor products through an elegant visual interface. | 50% OFF for Lifetime Plan with code **BF2025** |  Nov 20 - Dec 2  |
 
 [⬆️ Go to Top](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Don't forget to:
 ## 👨‍💻 Developer Tools
 | Badge | App | Category | Description | Deal | Start-End Date |
 |:---:|:---|:---|:---|:---|:---:|
-| 🔥 | [Dash](https://kapeli.com/dash)|Documentation Browser|Offline API Documentation browser and snippet manager|50% OFF with code [BLACKFRIDAY](https://kapeli.com/subscribe?coupon=BLACKFRIDAY)|Nov 4 - Nov 12|
+| 🔥 | [Dash](https://kapeli.com/dash)|Documentation Browser|Offline API Documentation browser and snippet manager|50% OFF with code [BLACKFRIDAY](https://kapeli.com/subscribe?coupon=BLACKFRIDAY)|Nov 4 - Dec 2|
 | 🔥 | [KeygenGo](https://keygengo.5km.tech) | Licensing & Distribution | A native macOS app that transforms your Keygen.sh experience. Manage licenses, track users, and monitor products through an elegant visual interface. | 50% OFF for Lifetime Plan with code **BF2025** |  Nov 20 - Dec 2  |
 
 [⬆️ Go to Top](#table-of-contents)


### PR DESCRIPTION
KeyGenGo did not follow the "add to bottom rule". I've restored the order.

Also, the Table of Contents link for Developer Tools doesn't work for me (in Chrome on macOS). I've fixed it.